### PR TITLE
Don't shell out to tar on Windows

### DIFF
--- a/extractor/tgz_extractor.go
+++ b/extractor/tgz_extractor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 )
 
 type tgzExtractor struct{}
@@ -36,15 +37,17 @@ func (e *tgzExtractor) Extract(src, dest string) error {
 }
 
 func extractTgz(src, dest string) error {
-	tarPath, err := exec.LookPath("tar")
+	if runtime.GOOS != "windows" {
+		tarPath, err := exec.LookPath("tar")
 
-	if err == nil {
-		err := os.MkdirAll(dest, 0755)
-		if err != nil {
-			return err
+		if err == nil {
+			err := os.MkdirAll(dest, 0755)
+			if err != nil {
+				return err
+			}
+
+			return exec.Command(tarPath, "pzxf", src, "-C", dest).Run()
 		}
-
-		return exec.Command(tarPath, "pzxf", src, "-C", dest).Run()
 	}
 
 	fd, err := os.Open(src)


### PR DESCRIPTION
When running in git bash (and you have tar in your path), this will fail.
